### PR TITLE
feat(bootstrap): Change buttons in top pannel 

### DIFF
--- a/src/Main/AxesButton.jsx
+++ b/src/Main/AxesButton.jsx
@@ -1,42 +1,28 @@
-import React, { useEffect, useRef } from 'react'
+import React from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, ToggleButton, Tooltip } from '@mui/material'
 import { axesIconDataUri } from 'itk-viewer-icons'
-import '../style.css'
+import Button from 'react-bootstrap/Button'
+import Image from 'react-bootstrap/Image'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
+import cn from 'classnames'
 
 function AxesButton(props) {
   const { service } = props
-  const axesButton = useRef(null)
   const [state, send] = useActor(service)
 
-  useEffect(() => {
-    state.context.main.axesButtonLabel = axesButton.current
-  }, [])
-
   return (
-    <Tooltip
-      ref={axesButton}
-      title="Axes"
-      PopperProps={{
-        anchorEl: axesButton.current,
-        disablePortal: true,
-        keepMounted: true
-      }}
-    >
-      <ToggleButton
-        size="small"
-        className="toggleButton"
-        value="axesVisible"
-        selected={state.context.main.axesEnabled}
-        onChange={() => {
-          send('TOGGLE_AXES')
-        }}
+    <OverlayTrigger transition={false} overlay={<Tooltip> Axes </Tooltip>}>
+      <Button
+        className={cn('icon-button', {
+          checked: state.context.main.axesEnabled
+        })}
+        onClick={() => send('TOGGLE_AXES')}
+        variant="secondary"
       >
-        <Icon>
-          <img src={axesIconDataUri} />
-        </Icon>
-      </ToggleButton>
-    </Tooltip>
+        <Image src={axesIconDataUri}></Image>
+      </Button>
+    </OverlayTrigger>
   )
 }
 

--- a/src/Main/BackgroundColorButton.jsx
+++ b/src/Main/BackgroundColorButton.jsx
@@ -1,39 +1,31 @@
-import React, { useEffect, useRef } from 'react'
+import React from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, IconButton, Tooltip } from '@mui/material'
 import { selectColorIconDataUri } from 'itk-viewer-icons'
-import '../style.css'
+import Button from 'react-bootstrap/Button'
+import Image from 'react-bootstrap/Image'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
+import cn from 'classnames'
 
 function BackgroundColorButton(props) {
   const { service } = props
-  const bgColorButton = useRef(null)
   const [state, send] = useActor(service)
 
-  useEffect(() => {
-    state.context.main.bgColorButtonLabel = bgColorButton.current
-  }, [])
-
   return (
-    <Tooltip
-      ref={bgColorButton}
-      title="Toggle Background Color"
-      PopperProps={{
-        anchorEl: bgColorButton.current,
-        disablePortal: true,
-        keepMounted: true
-      }}
-    >
-      <IconButton
-        size="small"
-        onClick={() => {
-          send('TOGGLE_BACKGROUND_COLOR')
-        }}
+      <OverlayTrigger
+        transition= {false}
+        overlay={<Tooltip> Toggle Background Color </Tooltip>}
       >
-        <Icon>
-          <img src={selectColorIconDataUri} />
-        </Icon>
-      </IconButton>
-    </Tooltip>
+          <Button className={cn('icon-button', {
+            checked : state.context.main.backgroundEnabled
+            })}
+            onClick={() => {
+            send('TOGGLE_BACKGROUND_COLOR'
+            )}}
+            variant="secondary"> 
+             <Image src={selectColorIconDataUri}/>
+          </Button>
+      </OverlayTrigger>
   )
 }
 

--- a/src/Main/BackgroundColorButton.jsx
+++ b/src/Main/BackgroundColorButton.jsx
@@ -12,20 +12,22 @@ function BackgroundColorButton(props) {
   const [state, send] = useActor(service)
 
   return (
-      <OverlayTrigger
-        transition= {false}
-        overlay={<Tooltip> Toggle Background Color </Tooltip>}
+    <OverlayTrigger
+      transition={false}
+      overlay={<Tooltip> Toggle Background Color </Tooltip>}
+    >
+      <Button
+        className={cn('icon-button', {
+          checked: state.context.main.backgroundColorsEnabled
+        })}
+        onClick={() => {
+          send('TOGGLE_BACKGROUND_COLOR')
+        }}
+        variant="secondary"
       >
-          <Button className={cn('icon-button', {
-            checked : state.context.main.backgroundEnabled
-            })}
-            onClick={() => {
-            send('TOGGLE_BACKGROUND_COLOR'
-            )}}
-            variant="secondary"> 
-             <Image src={selectColorIconDataUri}/>
-          </Button>
-      </OverlayTrigger>
+        <Image src={selectColorIconDataUri} />
+      </Button>
+    </OverlayTrigger>
   )
 }
 

--- a/src/Main/FullscreenButton.jsx
+++ b/src/Main/FullscreenButton.jsx
@@ -1,43 +1,32 @@
-import React, { useEffect, useRef } from 'react'
+import React from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, ToggleButton, Tooltip } from '@mui/material'
 import { fullscreenIconDataUri } from 'itk-viewer-icons'
-import '../style.css'
+import Button from 'react-bootstrap/Button'
+import Image from 'react-bootstrap/Image'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
+import cn from 'classnames'
 
 function FullscreenButton(props) {
   const { service } = props
-  const fullscreenButton = useRef(null)
   const [state, send] = useActor(service)
 
-  useEffect(() => {
-    state.context.main.fullscreenButton = fullscreenButton.current
-  }, [])
-
-  return (
-    <Tooltip
-      ref={fullscreenButton}
-      title="Fullscreen [f]"
-      PopperProps={{
-        anchorEl: fullscreenButton.current,
-        disablePortal: true,
-        keepMounted: true
-      }}
+  return ( 
+    <OverlayTrigger
+      transition={false}
+      overlay={<Tooltip> Fullscreen [f] </Tooltip>}
     >
-      <ToggleButton
-        size="small"
-        className="toggleButton"
-        value="fullscreenEnabled"
-        selected={state.context.main.fullscreenEnabled}
-        onChange={() => {
-          send('TOGGLE_FULLSCREEN')
-        }}
+      <Button
+      className={cn('icon-button', {
+        checked:state.context.main.fullscreenEnabled
+      })}
+      onClick={() => send('TOGGLE_FULLSCREEN')}
+      variant='secondary'
       >
-        <Icon>
-          <img src={fullscreenIconDataUri} />
-        </Icon>
-      </ToggleButton>
-    </Tooltip>
-  )
-}
+        <Image src={fullscreenIconDataUri}></Image>
+      </Button>
+    </OverlayTrigger>
+    )
+ }
 
 export default FullscreenButton

--- a/src/Main/ResetCameraButton.jsx
+++ b/src/Main/ResetCameraButton.jsx
@@ -1,40 +1,32 @@
-import React, { useEffect, useRef } from 'react'
+import React from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, IconButton, Tooltip } from '@mui/material'
 import { resetCameraIconDataUri } from 'itk-viewer-icons'
-import '../style.css'
+import Button from 'react-bootstrap/Button'
+import Image from 'react-bootstrap/Image'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
+import cn from 'classnames'
 
 function ResetCamerButton(props) {
   const { service } = props
-  const resetCameraButton = useRef(null)
   const [state, send] = useActor(service)
 
-  useEffect(() => {
-    state.context.main.resetCameraButtonLabel = resetCameraButton.current
-  }, [])
-
   return (
-    <Tooltip
-      ref={resetCameraButton}
-      title="Reset camera [r]"
-      PopperProps={{
-        anchorEl: resetCameraButton.current,
-        disablePortal: true,
-        keepMounted: true
-      }}
-    >
-      <IconButton
-        size="small"
-        onClick={() => {
-          send('RESET_CAMERA')
-        }}
-      >
-        <Icon>
-          <img src={resetCameraIconDataUri} />
-        </Icon>
-      </IconButton>
-    </Tooltip>
-  )
+    <OverlayTrigger
+      transition={false}
+      overlay={<Tooltip>Reset camera [r]</Tooltip>}
+     >
+     <Button
+        className={cn('icon-button', {
+          checked:state.context.main.resetCameraEnabled
+        })}
+        onClick={() =>send('RESET_CAMERA')}
+        variant='secondary'
+     >
+    <Image src={resetCameraIconDataUri}></Image>       
+     </Button>  
+     </OverlayTrigger>
+    )
 }
 
 export default ResetCamerButton

--- a/src/Main/ScreenshotButton.jsx
+++ b/src/Main/ScreenshotButton.jsx
@@ -1,38 +1,34 @@
-import React, { useEffect, useRef } from 'react'
+import React from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, IconButton, Tooltip } from '@mui/material'
 import { screenshotIconDataUri } from 'itk-viewer-icons'
+import Button from 'react-bootstrap/Button'
+import Image from 'react-bootstrap/Image'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
+import cn from 'classnames'
 
 function ScreenshotButton(props) {
   const { service } = props
-  const screenshotButton = useRef(null)
   const [state, send] = useActor(service)
 
-  useEffect(() => {
-    state.context.main.screenshotButton = screenshotButton.current
-  }, [])
-
   return (
-    <Tooltip
-      ref={screenshotButton}
-      title="Screenshot"
-      PopperProps={{
-        anchorEl: screenshotButton.current,
-        disablePortal: true,
-        keepMounted: true
-      }}
+    <OverlayTrigger
+      transition={false}
+      overlay={<Tooltip>Screenshot</Tooltip>}
     >
-      <IconButton
-        size="small"
+      <Button
+        className={cn('icon-button', {
+          checked:state.context.main.screenshotEnabled
+        })}
         onClick={() => {
           send('TAKE_SCREENSHOT')
         }}
+        variant='secondary'
       >
-        <Icon>
-          <img src={screenshotIconDataUri} />
-        </Icon>
-      </IconButton>
-    </Tooltip>
+          <Image src={screenshotIconDataUri}></Image>
+      </Button>
+    </OverlayTrigger>
+
   )
 }
 

--- a/src/Main/ViewModeButtons.jsx
+++ b/src/Main/ViewModeButtons.jsx
@@ -1,136 +1,78 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect } from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, ToggleButton, Tooltip } from '@mui/material'
 import {
   volumeIconDataUri,
   redPlaneIconDataUri,
   yellowPlaneIconDataUri,
   greenPlaneIconDataUri
 } from 'itk-viewer-icons'
+import Button from 'react-bootstrap/Button'
+import Image from 'react-bootstrap/Image'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
+import cn from 'classnames'
+
+function ViewButton(props) {
+  const [state, send] = useActor(props.service)
+  let dataNameLowerCase =
+    props.dataName.charAt(0).toLowerCase() + props.dataName.slice(1)
+  let enableButton = dataNameLowerCase + 'EnableButton'
+
+  return (
+    <OverlayTrigger
+      transition={false}
+      overlay={<Tooltip> {props.title} </Tooltip>}
+    >
+      <Button
+        className={cn('icon-button', {
+          checked: state.context.main[enableButton]
+        })}
+        onClick={() => {
+          send({ type: 'VIEW_MODE_CHANGED', data: props.dataName })
+        }}
+        variant="secondary"
+      >
+        <Image src={props.imageSrc}></Image>
+      </Button>
+    </OverlayTrigger>
+  )
+}
 
 function ViewModeButtons(props) {
   const { service } = props
-  const xPlaneButton = useRef(null)
-  const yPlaneButton = useRef(null)
-  const zPlaneButton = useRef(null)
-  const volumeButton = useRef(null)
-  const [state, send] = useActor(service)
 
-  useEffect(() => {
-    state.context.main.xPlaneButtonLabel = xPlaneButton.current
-    state.context.main.yPlaneButtonLabel = yPlaneButton.current
-    state.context.main.zPlaneButtonLabel = zPlaneButton.current
-    state.context.main.volumeButtonLabel = volumeButton.current
-  }, [])
-
-  return (
-    <div className="viewModeButtons">
-      <Tooltip
-        ref={xPlaneButton}
-        title="X plane [1]"
-        PopperProps={{
-          anchorEl: xPlaneButton.current,
-          disablePortal: true,
-          keepMounted: true
-        }}
-      >
-        <ToggleButton
-          size="small"
-          className="toggleButton"
-          value="xplane"
-          selected={state.context.main.xPlaneButton}
-          onChange={() => {
-            send({ type: 'VIEW_MODE_CHANGED', data: 'XPlane' })
-          }}
-        >
-          <Icon className="viewModeButton">
-            <img
-              style={{ height: '24px', width: '24px' }}
-              src={redPlaneIconDataUri}
-            />
-          </Icon>
-        </ToggleButton>
-      </Tooltip>
-      <Tooltip
-        ref={yPlaneButton}
-        title="Y plane [2]"
-        PopperProps={{
-          anchorEl: yPlaneButton.current,
-          disablePortal: true,
-          keepMounted: true
-        }}
-      >
-        <ToggleButton
-          size="small"
-          className="toggleButton"
-          value="yplane"
-          selected={state.context.main.yPlaneButton}
-          onClick={() => {
-            send({ type: 'VIEW_MODE_CHANGED', data: 'YPlane' })
-          }}
-        >
-          <Icon className="viewModeButton">
-            <img
-              style={{ height: '24px', width: '24px' }}
-              src={yellowPlaneIconDataUri}
-            />
-          </Icon>
-        </ToggleButton>
-      </Tooltip>
-      <Tooltip
-        ref={zPlaneButton}
-        title="z plane [3]"
-        PopperProps={{
-          anchorEl: zPlaneButton.current,
-          disablePortal: true,
-          keepMounted: true
-        }}
-      >
-        <ToggleButton
-          size="small"
-          className="toggleButton"
-          value="zplane"
-          selected={state.context.main.zPlaneButton}
-          onClick={() => {
-            send({ type: 'VIEW_MODE_CHANGED', data: 'ZPlane' })
-          }}
-        >
-          <Icon className="viewModeButton">
-            <img
-              style={{ height: '24px', width: '24px' }}
-              src={greenPlaneIconDataUri}
-            />
-          </Icon>
-        </ToggleButton>
-      </Tooltip>
-      <Tooltip
-        ref={volumeButton}
-        title="Volume [4]"
-        PopperProps={{
-          anchorEl: volumeButton.current,
-          disablePortal: true,
-          keepMounted: true
-        }}
-      >
-        <ToggleButton
-          size="small"
-          className="toggleButton"
-          value="volume"
-          selected={state.context.main.volumeButton}
-          onClick={() => {
-            send({ type: 'VIEW_MODE_CHANGED', data: 'Volume' })
-          }}
-        >
-          <Icon className="viewModeButton">
-            <img
-              style={{ height: '24px', width: '24px' }}
-              src={volumeIconDataUri}
-            />
-          </Icon>
-        </ToggleButton>
-      </Tooltip>
-    </div>
-  )
+  const buttonList = [
+    {
+      title: 'X plane [1]',
+      dataName: 'XPlane',
+      imageSrc: redPlaneIconDataUri
+    },
+    {
+      title: 'Y plane [2]',
+      dataName: 'YPlane',
+      imageSrc: yellowPlaneIconDataUri
+    },
+    {
+      title: 'Z plane [3]',
+      dataName: 'ZPlane',
+      imageSrc: greenPlaneIconDataUri
+    },
+    {
+      title: 'Volume [4]',
+      dataName: 'Volume',
+      imageSrc: volumeIconDataUri
+    }
+  ]
+  const listItems = buttonList.map(({ title, dataName, imageSrc }) => (
+    <ViewButton
+      key={title}
+      title={title}
+      dataName={dataName}
+      imageSrc={imageSrc}
+      service={service}
+    ></ViewButton>
+  ))
+  return listItems
 }
 
 export default ViewModeButtons

--- a/src/Main/ViewPlanesToggle.jsx
+++ b/src/Main/ViewPlanesToggle.jsx
@@ -1,17 +1,16 @@
-import React, { useEffect, useRef } from 'react'
+import React from 'react'
 import { useActor } from '@xstate/react'
-import { Icon, ToggleButton, Tooltip } from '@mui/material'
 import { viewPlanesIconDataUri } from 'itk-viewer-icons'
+import Button from 'react-bootstrap/Button'
+import Image from 'react-bootstrap/Image'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
+import cn from 'classnames'
 
 function ViewPlanesToggle(props) {
   const { service } = props
-  const viewPlanesButton = useRef(null)
   const [state, send] = useActor(service)
   const { slicingPlanes } = state.context.main
-
-  useEffect(() => {
-    state.context.main.viewPlanesButtonLabel = viewPlanesButton.current
-  }, [])
 
   const planesVisible = () => {
     return (
@@ -47,27 +46,17 @@ function ViewPlanesToggle(props) {
   }
 
   return (
-    <Tooltip
-      ref={viewPlanesButton}
-      title="View planes [s]"
-      PopperProps={{
-        anchorEl: viewPlanesButton.current,
-        disablePortal: true,
-        keepMounted: true
-      }}
-    >
-      <ToggleButton
-        size="small"
-        className="toggleButton"
-        value="visiblePlanes"
-        selected={planesVisible()}
-        onChange={handleToggle}
+    <OverlayTrigger transition={false} overlay={<Tooltip>View planes</Tooltip>}>
+      <Button
+        className={cn('icon-button', {
+          checked: state.context.main.viewPlanesEnabled
+        })}
+        onClick={handleToggle}
+        variant="secondary"
       >
-        <Icon>
-          <img src={viewPlanesIconDataUri} />
-        </Icon>
-      </ToggleButton>
-    </Tooltip>
+        <Image src={viewPlanesIconDataUri}></Image>
+      </Button>
+    </OverlayTrigger>
   )
 }
 


### PR DESCRIPTION
feat(bootstrap): Change buttons in top pannel 

Change top left pannel buttons framework from Material UI to Bootstrap. 
The buttons included in this change are: 
 - background color,
 - view planes, 
 - change axes,
 - reset camera,
 - screenshot,
 - fullscreen, 
 - background color.
These changes follow the changes for the annotations button introduced in commits  e5fd827 and 08aaa09 .

Co-authored-by: Paul Elliott <paul.elliott@kitware.com>