### PR TITLE
Optimize code, delete unnecessary statements, fix state props

### DIFF
--- a/src/Main/AnnotationsButton.jsx
+++ b/src/Main/AnnotationsButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useActor, useSelector } from '@xstate/react'
+import { useSelector } from '@xstate/react'
 import { annotationsIconDataUri } from 'itk-viewer-icons'
 import Button from 'react-bootstrap/Button'
 import Image from 'react-bootstrap/Image'
@@ -20,7 +20,6 @@ const AnnotationsButton = React.memo(function AnnotationsButton(props) {
     >
       <Button
         className={cn('icon-button', {
-          //checked: state.context.main.annotationsEnabled
           checked: stateAnnotationsEnabled
         })}
         onClick={() => send('TOGGLE_ANNOTATIONS')}

--- a/src/Main/AnnotationsButton.jsx
+++ b/src/Main/AnnotationsButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useActor } from '@xstate/react'
+import { useActor, useSelector } from '@xstate/react'
 import { annotationsIconDataUri } from 'itk-viewer-icons'
 import Button from 'react-bootstrap/Button'
 import Image from 'react-bootstrap/Image'
@@ -7,9 +7,11 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
-function AnnotationsButton(props) {
+const AnnotationsButton = React.memo(function AnnotationsButton(props) {
   const { service } = props
-  const [state, send] = useActor(service)
+  const selectCount = (state) => state.context.main.annotationsEnabled
+  const stateAnnotationsEnabled = useSelector(service, selectCount)
+  const send = service.send
 
   return (
     <OverlayTrigger
@@ -18,7 +20,8 @@ function AnnotationsButton(props) {
     >
       <Button
         className={cn('icon-button', {
-          checked: state.context.main.annotationsEnabled
+          //checked: state.context.main.annotationsEnabled
+          checked: stateAnnotationsEnabled
         })}
         onClick={() => send('TOGGLE_ANNOTATIONS')}
         variant="secondary"
@@ -27,6 +30,6 @@ function AnnotationsButton(props) {
       </Button>
     </OverlayTrigger>
   )
-}
+})
 
 export default AnnotationsButton

--- a/src/Main/AnnotationsButton.jsx
+++ b/src/Main/AnnotationsButton.jsx
@@ -9,8 +9,10 @@ import cn from 'classnames'
 
 const AnnotationsButton = React.memo(function AnnotationsButton(props) {
   const { service } = props
-  const selectCount = (state) => state.context.main.annotationsEnabled
-  const stateAnnotationsEnabled = useSelector(service, selectCount)
+  const stateAnnotationsEnabled = useSelector(
+    service,
+    (state) => state.context.main.annotationsEnabled
+  )
   const send = service.send
 
   return (

--- a/src/Main/AxesButton.jsx
+++ b/src/Main/AxesButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useActor } from '@xstate/react'
+import { useActor, useSelector } from '@xstate/react'
 import { axesIconDataUri } from 'itk-viewer-icons'
 import Button from 'react-bootstrap/Button'
 import Image from 'react-bootstrap/Image'
@@ -7,15 +7,17 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
-function AxesButton(props) {
+const AxesButton = React.memo(function AxesButton(props) {
   const { service } = props
-  const [state, send] = useActor(service)
+  const selectCount = (state) => state.context.main.axesEnabled
+  const stateAxesEnabled = useSelector(service, selectCount)
+  const send = service.send
 
   return (
     <OverlayTrigger transition={false} overlay={<Tooltip> Axes </Tooltip>}>
       <Button
         className={cn('icon-button', {
-          checked: state.context.main.axesEnabled
+          checked: stateAxesEnabled
         })}
         onClick={() => send('TOGGLE_AXES')}
         variant="secondary"
@@ -24,6 +26,6 @@ function AxesButton(props) {
       </Button>
     </OverlayTrigger>
   )
-}
+})
 
 export default AxesButton

--- a/src/Main/AxesButton.jsx
+++ b/src/Main/AxesButton.jsx
@@ -9,8 +9,10 @@ import cn from 'classnames'
 
 const AxesButton = React.memo(function AxesButton(props) {
   const { service } = props
-  const selectCount = (state) => state.context.main.axesEnabled
-  const stateAxesEnabled = useSelector(service, selectCount)
+  const stateAxesEnabled = useSelector(
+    service,
+    (state) => state.context.main.axesEnabled
+  )
   const send = service.send
 
   return (

--- a/src/Main/BackgroundColorButton.jsx
+++ b/src/Main/BackgroundColorButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useActor, useSelector } from '@xstate/react'
+import { useSelector } from '@xstate/react'
 import { selectColorIconDataUri } from 'itk-viewer-icons'
 import Button from 'react-bootstrap/Button'
 import Image from 'react-bootstrap/Image'
@@ -7,9 +7,9 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
-function BackgroundColorButton(props) {
+const BackgroundColorButton = React.memo(function BackgroundColorButton(props) {
   const { service } = props
-  const selectCount = (state) => state.context.main.backgroundColorsEnabled
+  const selectCount = (state) => state.context.main.selectedBackgroundColor
   const stateBackgroundColorEnabled = useSelector(service, selectCount)
   const send = service.send
 
@@ -31,6 +31,6 @@ function BackgroundColorButton(props) {
       </Button>
     </OverlayTrigger>
   )
-}
+})
 
 export default BackgroundColorButton

--- a/src/Main/BackgroundColorButton.jsx
+++ b/src/Main/BackgroundColorButton.jsx
@@ -9,8 +9,10 @@ import cn from 'classnames'
 
 const BackgroundColorButton = React.memo(function BackgroundColorButton(props) {
   const { service } = props
-  const selectCount = (state) => state.context.main.selectedBackgroundColor
-  const stateBackgroundColorEnabled = useSelector(service, selectCount)
+  const stateBackgroundColorEnabled = useSelector(
+    service,
+    (state) => state.context.main.selectedBackgroundColor
+  )
   const send = service.send
 
   return (

--- a/src/Main/BackgroundColorButton.jsx
+++ b/src/Main/BackgroundColorButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useActor } from '@xstate/react'
+import { useActor, useSelector } from '@xstate/react'
 import { selectColorIconDataUri } from 'itk-viewer-icons'
 import Button from 'react-bootstrap/Button'
 import Image from 'react-bootstrap/Image'
@@ -9,7 +9,9 @@ import cn from 'classnames'
 
 function BackgroundColorButton(props) {
   const { service } = props
-  const [state, send] = useActor(service)
+  const selectCount = (state) => state.context.main.backgroundColorsEnabled
+  const stateBackgroundColorEnabled = useSelector(service, selectCount)
+  const send = service.send
 
   return (
     <OverlayTrigger
@@ -18,7 +20,7 @@ function BackgroundColorButton(props) {
     >
       <Button
         className={cn('icon-button', {
-          checked: state.context.main.backgroundColorsEnabled
+          checked: stateBackgroundColorEnabled
         })}
         onClick={() => {
           send('TOGGLE_BACKGROUND_COLOR')

--- a/src/Main/FullscreenButton.jsx
+++ b/src/Main/FullscreenButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useActor } from '@xstate/react'
+import { useActor, useSelector } from '@xstate/react'
 import { fullscreenIconDataUri } from 'itk-viewer-icons'
 import Button from 'react-bootstrap/Button'
 import Image from 'react-bootstrap/Image'
@@ -7,26 +7,28 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
-function FullscreenButton(props) {
+const FullscreenButton = React.memo(function FullscreenButton(props) {
   const { service } = props
-  const [state, send] = useActor(service)
+  const selectCount = (state) => state.context.main.fullscreenEnabled
+  const stateFullscreenEnabled = useSelector(service, selectCount)
+  const send = service.send
 
-  return ( 
+  return (
     <OverlayTrigger
       transition={false}
       overlay={<Tooltip> Fullscreen [f] </Tooltip>}
     >
       <Button
-      className={cn('icon-button', {
-        checked:state.context.main.fullscreenEnabled
-      })}
-      onClick={() => send('TOGGLE_FULLSCREEN')}
-      variant='secondary'
+        className={cn('icon-button', {
+          checked: stateFullscreenEnabled
+        })}
+        onClick={() => send('TOGGLE_FULLSCREEN')}
+        variant="secondary"
       >
         <Image src={fullscreenIconDataUri}></Image>
       </Button>
     </OverlayTrigger>
-    )
- }
+  )
+})
 
 export default FullscreenButton

--- a/src/Main/FullscreenButton.jsx
+++ b/src/Main/FullscreenButton.jsx
@@ -9,8 +9,10 @@ import cn from 'classnames'
 
 const FullscreenButton = React.memo(function FullscreenButton(props) {
   const { service } = props
-  const selectCount = (state) => state.context.main.fullscreenEnabled
-  const stateFullscreenEnabled = useSelector(service, selectCount)
+  const stateFullscreenEnabled = useSelector(
+    service,
+    (state) => state.context.main.fullscreenEnabled
+  )
   const send = service.send
 
   return (

--- a/src/Main/MainInterface.jsx
+++ b/src/Main/MainInterface.jsx
@@ -12,6 +12,8 @@ import ViewModeButtons from './ViewModeButtons'
 import ViewPlanesToggle from './ViewPlanesToggle'
 import '../style.css'
 
+const STYLE = { width: '20%' }
+
 function MainInterface(props) {
   const { service } = props
   const [state] = useActor(service)
@@ -37,7 +39,7 @@ function MainInterface(props) {
         {!state.context.use2D && (
           <div className="mainUIRow">
             <ViewModeButtons {...props} />
-            <ResetCameraButton style={{ width: '20%' }} {...props} />
+            <ResetCameraButton style={STYLE} {...props} />
           </div>
         )}
       </div>

--- a/src/Main/ResetCameraButton.jsx
+++ b/src/Main/ResetCameraButton.jsx
@@ -5,9 +5,8 @@ import Image from 'react-bootstrap/Image'
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 
-const ResetCamerButton = React.memo(function ResetCamerButton(props) {
-  const { service } = props
-  const send = service.send
+const ResetCamerButton = React.memo(function ResetCamerButton({ service }) {
+  const { send } = service
 
   return (
     <OverlayTrigger

--- a/src/Main/ResetCameraButton.jsx
+++ b/src/Main/ResetCameraButton.jsx
@@ -1,32 +1,28 @@
 import React from 'react'
-import { useActor } from '@xstate/react'
 import { resetCameraIconDataUri } from 'itk-viewer-icons'
 import Button from 'react-bootstrap/Button'
 import Image from 'react-bootstrap/Image'
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
-import cn from 'classnames'
 
-function ResetCamerButton(props) {
+const ResetCamerButton = React.memo(function ResetCamerButton(props) {
   const { service } = props
-  const [state, send] = useActor(service)
+  const send = service.send
 
   return (
     <OverlayTrigger
       transition={false}
       overlay={<Tooltip>Reset camera [r]</Tooltip>}
-     >
-     <Button
-        className={cn('icon-button', {
-          checked:state.context.main.resetCameraEnabled
-        })}
-        onClick={() =>send('RESET_CAMERA')}
-        variant='secondary'
-     >
-    <Image src={resetCameraIconDataUri}></Image>       
-     </Button>  
-     </OverlayTrigger>
-    )
-}
+    >
+      <Button
+        className={'icon-button'}
+        onClick={() => send('RESET_CAMERA')}
+        variant="secondary"
+      >
+        <Image src={resetCameraIconDataUri}></Image>
+      </Button>
+    </OverlayTrigger>
+  )
+})
 
 export default ResetCamerButton

--- a/src/Main/RotateButton.jsx
+++ b/src/Main/RotateButton.jsx
@@ -7,7 +7,7 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
-function RotateButton(props) {
+const RotateButton = React.memo(function RotateButton(props) {
   const { service } = props
   const selectCount = (state) => state.context.main.rotateEnabled
   const stateRotateEnabled = useSelector(service, selectCount)
@@ -29,6 +29,6 @@ function RotateButton(props) {
       </Button>
     </OverlayTrigger>
   )
-}
+})
 
 export default RotateButton

--- a/src/Main/RotateButton.jsx
+++ b/src/Main/RotateButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useActor } from '@xstate/react'
+import { useActor, useSelector } from '@xstate/react'
 import { rotateIconDataUri } from 'itk-viewer-icons'
 import Button from 'react-bootstrap/Button'
 import Image from 'react-bootstrap/Image'
@@ -8,27 +8,27 @@ import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
 function RotateButton(props) {
-const { service } = props	
-const [state, send] = useActor(service)
+  const { service } = props
+  const selectCount = (state) => state.context.main.rotateEnabled
+  const stateRotateEnabled = useSelector(service, selectCount)
+  const send = service.send
 
-
-return ( 
-  <OverlayTrigger 
-    transition = {false}
-    overlay={<Tooltip> Spin in 3D [p] </Tooltip>}
-  >
-    <Button
-      className={cn('icon-button', {
-        checked: state.context.main.rotateEnabled
-      })}
-      onClick= {() => send('TOGGLE_ROTATE')}
-      variant = "secondary"
+  return (
+    <OverlayTrigger
+      transition={false}
+      overlay={<Tooltip> Spin in 3D [p] </Tooltip>}
     >
-      <Image src={rotateIconDataUri}></Image>
-    </Button>
-  </OverlayTrigger>
+      <Button
+        className={cn('icon-button', {
+          checked: stateRotateEnabled
+        })}
+        onClick={() => send('TOGGLE_ROTATE')}
+        variant="secondary"
+      >
+        <Image src={rotateIconDataUri}></Image>
+      </Button>
+    </OverlayTrigger>
   )
 }
 
 export default RotateButton
-

--- a/src/Main/RotateButton.jsx
+++ b/src/Main/RotateButton.jsx
@@ -9,8 +9,10 @@ import cn from 'classnames'
 
 const RotateButton = React.memo(function RotateButton(props) {
   const { service } = props
-  const selectCount = (state) => state.context.main.rotateEnabled
-  const stateRotateEnabled = useSelector(service, selectCount)
+  const stateRotateEnabled = useSelector(
+    service,
+    (state) => state.context.main.rotateEnabled
+  )
   const send = service.send
 
   return (

--- a/src/Main/ScreenshotButton.jsx
+++ b/src/Main/ScreenshotButton.jsx
@@ -1,24 +1,18 @@
 import React from 'react'
-import { useActor, useSelector } from '@xstate/react'
 import { screenshotIconDataUri } from 'itk-viewer-icons'
 import Button from 'react-bootstrap/Button'
 import Image from 'react-bootstrap/Image'
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
-import cn from 'classnames'
 
-function ScreenshotButton(props) {
+const ScreenshotButton = React.memo(function ScreenshotButton(props) {
   const { service } = props
-  const selectCount = (state) => state.context.main.screenshotEnabled
-  const stateScreenshotEnabled = useSelector(service, selectCount)
   const send = service.send
 
   return (
     <OverlayTrigger transition={false} overlay={<Tooltip>Screenshot</Tooltip>}>
       <Button
-        className={cn('icon-button', {
-          checked: stateScreenshotEnabled
-        })}
+        className={'icon-button'}
         onClick={() => {
           send('TAKE_SCREENSHOT')
         }}
@@ -28,6 +22,6 @@ function ScreenshotButton(props) {
       </Button>
     </OverlayTrigger>
   )
-}
+})
 
 export default ScreenshotButton

--- a/src/Main/ScreenshotButton.jsx
+++ b/src/Main/ScreenshotButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useActor } from '@xstate/react'
+import { useActor, useSelector } from '@xstate/react'
 import { screenshotIconDataUri } from 'itk-viewer-icons'
 import Button from 'react-bootstrap/Button'
 import Image from 'react-bootstrap/Image'
@@ -9,26 +9,24 @@ import cn from 'classnames'
 
 function ScreenshotButton(props) {
   const { service } = props
-  const [state, send] = useActor(service)
+  const selectCount = (state) => state.context.main.screenshotEnabled
+  const stateScreenshotEnabled = useSelector(service, selectCount)
+  const send = service.send
 
   return (
-    <OverlayTrigger
-      transition={false}
-      overlay={<Tooltip>Screenshot</Tooltip>}
-    >
+    <OverlayTrigger transition={false} overlay={<Tooltip>Screenshot</Tooltip>}>
       <Button
         className={cn('icon-button', {
-          checked:state.context.main.screenshotEnabled
+          checked: stateScreenshotEnabled
         })}
         onClick={() => {
           send('TAKE_SCREENSHOT')
         }}
-        variant='secondary'
+        variant="secondary"
       >
-          <Image src={screenshotIconDataUri}></Image>
+        <Image src={screenshotIconDataUri}></Image>
       </Button>
     </OverlayTrigger>
-
   )
 }
 

--- a/src/Main/ViewModeButtons.jsx
+++ b/src/Main/ViewModeButtons.jsx
@@ -40,7 +40,7 @@ function ViewButton(props) {
 const ViewModeButtons = React.memo(function ViewModeButtons(props) {
   const { service } = props
 
-  const buttonList = [
+  return [
     {
       title: 'X plane [1]',
       dataName: 'XPlane',
@@ -61,8 +61,7 @@ const ViewModeButtons = React.memo(function ViewModeButtons(props) {
       dataName: 'Volume',
       imageSrc: volumeIconDataUri
     }
-  ]
-  const listItems = buttonList.map(({ title, dataName, imageSrc }) => (
+  ].map(({ title, dataName, imageSrc }) => (
     <ViewButton
       key={title}
       title={title}
@@ -71,7 +70,6 @@ const ViewModeButtons = React.memo(function ViewModeButtons(props) {
       service={service}
     ></ViewButton>
   ))
-  return listItems
 })
 
 export default ViewModeButtons

--- a/src/Main/ViewModeButtons.jsx
+++ b/src/Main/ViewModeButtons.jsx
@@ -13,8 +13,10 @@ import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
 function ViewButton(props) {
-  const selectCount = (state) => state.context.main.viewMode
-  const stateButtonEnabled = useSelector(props.service, selectCount)
+  const stateButtonEnabled = useSelector(
+    props.service,
+    (state) => state.context.main.viewMode
+  )
   const send = props.service.send
 
   return (

--- a/src/Main/ViewModeButtons.jsx
+++ b/src/Main/ViewModeButtons.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useActor } from '@xstate/react'
+import { useActor, useSelector } from '@xstate/react'
 import {
   volumeIconDataUri,
   redPlaneIconDataUri,
@@ -13,10 +13,12 @@ import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
 function ViewButton(props) {
-  const [state, send] = useActor(props.service)
   let dataNameLowerCase =
     props.dataName.charAt(0).toLowerCase() + props.dataName.slice(1)
   let enableButton = dataNameLowerCase + 'EnableButton'
+  const selectCount = (state) => state.context.main[enableButton]
+  const stateButtonEnabled = useSelector(props.service, selectCount)
+  const send = props.service.send
 
   return (
     <OverlayTrigger
@@ -25,7 +27,7 @@ function ViewButton(props) {
     >
       <Button
         className={cn('icon-button', {
-          checked: state.context.main[enableButton]
+          checked: stateButtonEnabled
         })}
         onClick={() => {
           send({ type: 'VIEW_MODE_CHANGED', data: props.dataName })
@@ -38,7 +40,7 @@ function ViewButton(props) {
   )
 }
 
-function ViewModeButtons(props) {
+const ViewModeButtons = React.memo(function ViewModeButtons(props) {
   const { service } = props
 
   const buttonList = [
@@ -73,6 +75,6 @@ function ViewModeButtons(props) {
     ></ViewButton>
   ))
   return listItems
-}
+})
 
 export default ViewModeButtons

--- a/src/Main/ViewModeButtons.jsx
+++ b/src/Main/ViewModeButtons.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { useActor, useSelector } from '@xstate/react'
+import { useSelector } from '@xstate/react'
 import {
   volumeIconDataUri,
   redPlaneIconDataUri,
@@ -13,10 +13,7 @@ import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
 function ViewButton(props) {
-  let dataNameLowerCase =
-    props.dataName.charAt(0).toLowerCase() + props.dataName.slice(1)
-  let enableButton = dataNameLowerCase + 'EnableButton'
-  const selectCount = (state) => state.context.main[enableButton]
+  const selectCount = (state) => state.context.main.viewMode
   const stateButtonEnabled = useSelector(props.service, selectCount)
   const send = props.service.send
 
@@ -27,7 +24,7 @@ function ViewButton(props) {
     >
       <Button
         className={cn('icon-button', {
-          checked: stateButtonEnabled
+          checked: stateButtonEnabled === props.dataName
         })}
         onClick={() => {
           send({ type: 'VIEW_MODE_CHANGED', data: props.dataName })

--- a/src/Main/ViewPlanesToggle.jsx
+++ b/src/Main/ViewPlanesToggle.jsx
@@ -8,8 +8,7 @@ import Tooltip from 'react-bootstrap/Tooltip'
 
 const ViewPlanesToggle = React.memo(function ViewPlanesToggle(props) {
   const { service } = props
-  const selectCount = (state) => state.context.main
-  const stateSlicingPlanes = useSelector(service, selectCount)
+  const stateSlicingPlanes = useSelector(service, (state) => state.context.main)
   const send = service.send
   const { slicingPlanes } = stateSlicingPlanes
 

--- a/src/Main/ViewPlanesToggle.jsx
+++ b/src/Main/ViewPlanesToggle.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useActor } from '@xstate/react'
+import { useActor, useSelector } from '@xstate/react'
 import { viewPlanesIconDataUri } from 'itk-viewer-icons'
 import Button from 'react-bootstrap/Button'
 import Image from 'react-bootstrap/Image'
@@ -9,8 +9,11 @@ import cn from 'classnames'
 
 function ViewPlanesToggle(props) {
   const { service } = props
-  const [state, send] = useActor(service)
-  const { slicingPlanes } = state.context.main
+  const selectCount = (state) => state.context.main
+  const stateSlicingPlanes = useSelector(service, selectCount)
+  const send = service.send
+  const { slicingPlanes } = stateSlicingPlanes
+  const stateViewPlanesEnabled = stateSlicingPlanes.viewPlanesEnabled
 
   const planesVisible = () => {
     return (
@@ -49,7 +52,7 @@ function ViewPlanesToggle(props) {
     <OverlayTrigger transition={false} overlay={<Tooltip>View planes</Tooltip>}>
       <Button
         className={cn('icon-button', {
-          checked: state.context.main.viewPlanesEnabled
+          checked: stateViewPlanesEnabled
         })}
         onClick={handleToggle}
         variant="secondary"

--- a/src/Main/ViewPlanesToggle.jsx
+++ b/src/Main/ViewPlanesToggle.jsx
@@ -1,19 +1,17 @@
 import React from 'react'
-import { useActor, useSelector } from '@xstate/react'
+import { useSelector } from '@xstate/react'
 import { viewPlanesIconDataUri } from 'itk-viewer-icons'
 import Button from 'react-bootstrap/Button'
 import Image from 'react-bootstrap/Image'
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
-import cn from 'classnames'
 
-function ViewPlanesToggle(props) {
+const ViewPlanesToggle = React.memo(function ViewPlanesToggle(props) {
   const { service } = props
   const selectCount = (state) => state.context.main
   const stateSlicingPlanes = useSelector(service, selectCount)
   const send = service.send
   const { slicingPlanes } = stateSlicingPlanes
-  const stateViewPlanesEnabled = stateSlicingPlanes.viewPlanesEnabled
 
   const planesVisible = () => {
     return (
@@ -51,9 +49,7 @@ function ViewPlanesToggle(props) {
   return (
     <OverlayTrigger transition={false} overlay={<Tooltip>View planes</Tooltip>}>
       <Button
-        className={cn('icon-button', {
-          checked: stateViewPlanesEnabled
-        })}
+        className={'icon-button'}
         onClick={handleToggle}
         variant="secondary"
       >
@@ -61,6 +57,6 @@ function ViewPlanesToggle(props) {
       </Button>
     </OverlayTrigger>
   )
-}
+})
 
 export default ViewPlanesToggle


### PR DESCRIPTION
Introduced a combination of `useSelector`, to obtain send and state, and React.memo. This approach avoids re-rendering all buttons when one of them has been clicked.
    The change has been applied to the buttons:
     - Annotations
     - Axes
     - Full screen
     - Background color
     - Rotate
     - View mode buttons
     - View planes toggle
     - Reset camera* - keeps re-rendering / needs more investigation
     - Screenshot
Fixed/replaced the states variables that showed up as `undefined` in the previous pull request.  
Deleted unnecessary statements including `useActor` and `cn`.

Co-authored-by: Paul Elliott <paul.elliott@kitware.com>