### PR TITLE
feat(SampleDistanceSlider/Style): Align center of button with slider, enable press-down feature

### DIFF
--- a/src/Images/BlendModeSelector.jsx
+++ b/src/Images/BlendModeSelector.jsx
@@ -63,7 +63,7 @@ function BlendModeSelector(props) {
         transition={false}
         overlay={<Tooltip>Blend mode</Tooltip>}
       >
-        <div className="icon-image blendModeButton">
+        <div className="icon-button blendModeButton">
           <Image src={blendModeIconDataUri}></Image>
         </div>
       </OverlayTrigger>

--- a/src/Images/BlendModeSelector.jsx
+++ b/src/Images/BlendModeSelector.jsx
@@ -1,30 +1,34 @@
 import React, { useEffect, useRef } from 'react'
-import { useActor } from '@xstate/react'
-import { Icon, MenuItem, Select, Tooltip } from '@mui/material'
+import { useSelector } from '@xstate/react'
 import { blendModeIconDataUri } from 'itk-viewer-icons'
 import applyContrastSensitiveStyleToElement from '../applyContrastSensitiveStyleToElement'
+import Image from 'react-bootstrap/Image'
+import Form from 'react-bootstrap/Form'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
 import '../style.css'
 
 function BlendModeSelector(props) {
   const { service } = props
+  const send = service.send
   const blendModeDiv = useRef(null)
   const blendModeSelector = useRef(null)
   const blendModeIcon = useRef(null)
-  const [state, send] = useActor(service)
+  const stateContext = useSelector(service, (state) => state.context)
 
   useEffect(() => {
     applyContrastSensitiveStyleToElement(
-      state.context,
+      stateContext,
       'invertibleButton',
       blendModeIcon.current
     )
-    state.context.images.blendModeDiv = blendModeIcon.current
-    state.context.images.blendModeSelector = blendModeSelector.current
+    stateContext.images.blendModeDiv = blendModeIcon.current
+    stateContext.images.blendModeSelector = blendModeSelector.current
   }, [])
 
   const selectionChanged = (event) => {
     const value = parseInt(event.target.value)
-    state.context.images.blendModeSelector.value = value
+    stateContext.images.blendModeSelector.value = value
     let mode = 'blendmode'
     switch (value) {
       case 0:
@@ -43,7 +47,7 @@ function BlendModeSelector(props) {
     send({
       type: 'IMAGE_BLEND_MODE_CHANGED',
       data: {
-        name: state.context.images.selectedName,
+        name: stateContext.images.selectedName,
         blendMode: mode
       }
     })
@@ -51,38 +55,27 @@ function BlendModeSelector(props) {
 
   return (
     <div ref={blendModeDiv} className="blendSelector">
-      <Tooltip
-        ref={blendModeIcon}
-        title="Blend mode"
-        PopperProps={{
-          anchorEl: blendModeIcon.current,
-          disablePortal: true,
-          keepMounted: true
-        }}
+      <OverlayTrigger
+        transition={false}
+        overlay={<Tooltip>Blend mode</Tooltip>}
       >
-        <Icon className="blendModeButton">
-          <img src={blendModeIconDataUri} />
-        </Icon>
-      </Tooltip>
-      <Select
+        <div className="icon-image blendModeButton">
+          <Image src={blendModeIconDataUri}></Image>
+        </div>
+      </OverlayTrigger>
+      <Form.Control
+        as="select"
         ref={blendModeSelector}
-        className="selector"
-        defaultValue={0}
+        className="selector blendMenu"
         onChange={(event) => {
           selectionChanged(event)
         }}
-        MenuProps={{
-          anchorEl: blendModeSelector.current,
-          disablePortal: true,
-          keepMounted: true,
-          classes: { paper: 'blendMenu' }
-        }}
       >
-        <MenuItem value={0}>Composite</MenuItem>
-        <MenuItem value={1}>Maximum</MenuItem>
-        <MenuItem value={2}>Minimum</MenuItem>
-        <MenuItem value={3}>Average</MenuItem>
-      </Select>
+        <option value={0}>Composite</option>
+        <option value={1}>Maximum</option>
+        <option value={2}>Minimum</option>
+        <option value={3}>Average</option>
+      </Form.Control>
     </div>
   )
 }

--- a/src/Images/BlendModeSelector.jsx
+++ b/src/Images/BlendModeSelector.jsx
@@ -63,7 +63,7 @@ function BlendModeSelector(props) {
         transition={false}
         overlay={<Tooltip>Blend mode</Tooltip>}
       >
-        <div className="icon-button blendModeButton">
+        <div className="icon-image">
           <Image src={blendModeIconDataUri}></Image>
         </div>
       </OverlayTrigger>

--- a/src/Images/BlendModeSelector.jsx
+++ b/src/Images/BlendModeSelector.jsx
@@ -14,6 +14,10 @@ function BlendModeSelector(props) {
   const blendModeDiv = useRef(null)
   const blendModeSelector = useRef(null)
   const blendModeIcon = useRef(null)
+  const selectedName = useSelector(
+    service,
+    (state) => state.context.images.selectedName
+  )
   const stateContext = useSelector(service, (state) => state.context)
 
   useEffect(() => {
@@ -22,13 +26,13 @@ function BlendModeSelector(props) {
       'invertibleButton',
       blendModeIcon.current
     )
-    stateContext.images.blendModeDiv = blendModeIcon.current
-    stateContext.images.blendModeSelector = blendModeSelector.current
+    service.machine.context.images.blendModeDiv = blendModeIcon.current
+    service.machine.context.images.blendModeSelector = blendModeSelector.current
   }, [])
 
   const selectionChanged = (event) => {
     const value = parseInt(event.target.value)
-    stateContext.images.blendModeSelector.value = value
+    service.machine.context.images.blendModeSelector.value = value
     let mode = 'blendmode'
     switch (value) {
       case 0:
@@ -47,7 +51,7 @@ function BlendModeSelector(props) {
     send({
       type: 'IMAGE_BLEND_MODE_CHANGED',
       data: {
-        name: stateContext.images.selectedName,
+        name: selectedName,
         blendMode: mode
       }
     })

--- a/src/Images/SampleDistanceSlider.jsx
+++ b/src/Images/SampleDistanceSlider.jsx
@@ -49,7 +49,7 @@ function SampleDistanceSlider(props) {
         transition={false}
         overlay={<Tooltip>Volume sample distance</Tooltip>}
       >
-        <div className="icon-button icon-image" ref={spacingDiv}>
+        <div className="icon-image" ref={spacingDiv}>
           <Image src={sampleDistanceIconDataUri}></Image>
         </div>
       </OverlayTrigger>

--- a/src/Images/SampleDistanceSlider.jsx
+++ b/src/Images/SampleDistanceSlider.jsx
@@ -49,7 +49,7 @@ function SampleDistanceSlider(props) {
         transition={false}
         overlay={<Tooltip>Volume sample distance</Tooltip>}
       >
-        <div className="icon-button" ref={spacingDiv}>
+        <div className="icon-image" ref={spacingDiv}>
           <Image src={sampleDistanceIconDataUri}></Image>
         </div>
       </OverlayTrigger>

--- a/src/Images/SampleDistanceSlider.jsx
+++ b/src/Images/SampleDistanceSlider.jsx
@@ -49,7 +49,7 @@ function SampleDistanceSlider(props) {
         transition={false}
         overlay={<Tooltip>Volume sample distance</Tooltip>}
       >
-        <div className="icon-image" ref={spacingDiv}>
+        <div className="icon-button icon-image" ref={spacingDiv}>
           <Image src={sampleDistanceIconDataUri}></Image>
         </div>
       </OverlayTrigger>

--- a/src/style.css
+++ b/src/style.css
@@ -27,13 +27,8 @@
 } 
 
 .icon-image {
-  background-color: transparent !important;
-  border-color: transparent !important;
   margin-right: 10px;
 }
-.icon-image > img {
-  width: 1.2rem;
-} 
 
 .categoricalMenu {
   margin: 0 5px !important;

--- a/src/style.css
+++ b/src/style.css
@@ -26,6 +26,15 @@
   width: 1.2rem;
 } 
 
+.icon-image {
+  background-color: transparent !important;
+  border-color: transparent !important;
+  margin-right: 10px;
+}
+.icon-image > img {
+  width: 1.2rem;
+} 
+
 .categoricalMenu {
   margin: 0 5px !important;
 }
@@ -307,6 +316,7 @@ code.uiContainer {
   width: 5px;
   align-self: center;
   margin-right: 5px;
+  margin-top: 7px;
 }
 
 .sliderEntry {

--- a/src/style.css
+++ b/src/style.css
@@ -2,32 +2,10 @@
   min-width: 125px !important;
 }
 
-.blendModeButton {
-  margin-right: 5px;
-}
-
 .blendSelector {
   display: flex;
   align-items: center;
   margin-left: 10px;
-}
-
-.icon-button {
-  background-color: transparent !important;
-  border-color: transparent !important;
-} 
-.icon-button > img {
-  width: 1.2rem;
-} 
- .icon-button:active, .icon-button:focus {
-  background-color:  rgba(255, 255, 255, 0.3) !important; 
-}
-.checked {
-  background-color: #5a6268 !important; 
-}
-
-.icon-image {
-  margin-right: 10px;
 }
 
 .categoricalMenu {
@@ -111,6 +89,32 @@ code.uiContainer {
   height: 0px !important;
   margin: 0px !important;
 }
+
+.icon-button {
+  background-color: transparent !important;
+  border-color: transparent !important;
+} 
+.icon-button > img {
+  width: 1.2rem;
+} 
+ .icon-button:active, .icon-button:focus {
+  background-color:  rgba(255, 255, 255, 0.3) !important; 
+}
+.checked {
+  background-color: #5a6268 !important; 
+}
+
+.icon-image {
+  background-color: transparent !important;
+  border-color: transparent !important;
+  margin-right: 10px;
+}
+.icon-image > img {
+  width: 1.2rem;
+}
+.icon-image:active, .icon-image:focus {
+  background-color:  transparent !important; 
+} 
 
 .iconWithSlider {
   width: 100%;

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,5 @@
 .blendMenu {
-  min-width: auto !important;
+  min-width: 125px !important;
 }
 
 .blendModeButton {

--- a/src/style.css
+++ b/src/style.css
@@ -91,10 +91,10 @@ code.uiContainer {
 
 .gradientOpacityInput {
   position: absolute !important;
-  bottom: 68px;
-  left: -45px;
+  bottom: 25px;
+  left: -38px;
   width:30px !important;
-  height: 110px !important;
+  height: 140px !important;
   -webkit-appearance: slider-vertical;
   }  
   

--- a/src/style.css
+++ b/src/style.css
@@ -12,19 +12,19 @@
   margin-left: 10px;
 }
 
-
-.btn-secondary:hover, .btn-secondary:focus, .btn-secondary:active {
-  background-color: #5a6268 !important;
-  border-color: #5a6268 !important; 
-} 
-
 .icon-button {
   background-color: transparent !important;
   border-color: transparent !important;
-}
+} 
 .icon-button > img {
   width: 1.2rem;
 } 
+ .icon-button:active, .icon-button:focus {
+  background-color:  rgba(255, 255, 255, 0.3) !important; 
+}
+.checked {
+  background-color: #5a6268 !important; 
+}
 
 .icon-image {
   margin-right: 10px;


### PR DESCRIPTION
 - Create different selector for icon image so we can have a rule for the right margin.  This prevents vents the overlap between the slider and the icon.
 - Introduce `margin-top` rule in the style.css to align vertically the button/image icon and the slider.
- Change appearance of vertical slider
- Make buttons stay pressed down by using the selector `.checked` and change the color of `:focus` so it is different than the checked mode.  