### PR TITLE
feat(top-level): Optimization of parent components

### DIFF
--- a/src/AppToolbar.jsx
+++ b/src/AppToolbar.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react'
-import { useActor } from '@xstate/react'
+import { useSelector } from '@xstate/react'
 import { AppBar, Icon, IconButton, Toolbar, Typography } from '@mui/material'
 import { toggleIconDataUri } from 'itk-viewer-icons'
 import toggleUICollapsed from './toggleUICollapsed'
@@ -7,16 +7,49 @@ import './Panel.css'
 
 function AppToolbar(props) {
   const { service } = props
+  const send = service.send
   const collapseUIButton = useRef(null)
-  const [state, send] = useActor(service)
+  let contextCollapseUIButton = useSelector(
+    service,
+    (state) => state.context.collapseUIButton
+  )
+  const uiContainer = useSelector(service, (state) => state.context.uiContainer)
+  const uiCollapsed = useSelector(service, (state) => state.context.uiCollapsed)
+
+  const selectedName = useSelector(
+    service,
+    (state) => state.context.images.selectedName
+  )
+
+  const use2D = useSelector(service, (state) => state.context.use2D)
+
+  const planeUIGroup = useSelector(
+    service,
+    (state) => state.context.planeUIGroup
+  )
+
+  const viewMode = useSelector(service, (state) => state.context.viewMode)
+  const mainPlaneUIGroup = useSelector(
+    service,
+    (state) => state.context.main.planeUIGroup
+  )
 
   useEffect(() => {
-    state.context.main.collapseUIButton = collapseUIButton.current
+    contextCollapseUIButton = collapseUIButton.current
   }, [])
 
   const handleToggle = () => {
     send('TOGGLE_UI_COLLAPSED')
-    toggleUICollapsed(state.context)
+    toggleUICollapsed(
+      uiContainer,
+      uiCollapsed,
+      selectedName,
+      service,
+      use2D,
+      planeUIGroup,
+      viewMode,
+      mainPlaneUIGroup
+    )
   }
 
   return (

--- a/src/CollapseUIButton.jsx
+++ b/src/CollapseUIButton.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react'
-import { useActor } from '@xstate/react'
+import { useSelector } from '@xstate/react'
 import { Icon, IconButton } from '@mui/material'
 import { toggleIconDataUri } from 'itk-viewer-icons'
 import toggleUICollapsed from './toggleUICollapsed'
@@ -9,6 +9,26 @@ function CollapseUIButton(props) {
   const { service } = props
   const collapseUIButton = useRef(null)
   const [state, send] = useActor(service)
+  const uiContainer = useSelector(service, (state) => state.context.uiContainer)
+  const uiCollapsed = useSelector(service, (state) => state.context.uiCollapsed)
+
+  const selectedName = useSelector(
+    service,
+    (state) => state.context.images.selectedName
+  )
+
+  const use2D = useSelector(service, (state) => state.context.use2D)
+
+  const planeUIGroup = useSelector(
+    service,
+    (state) => state.context.planeUIGroup
+  )
+
+  const viewMode = useSelector(service, (state) => state.context.viewMode)
+  const mainPlaneUIGroup = useSelector(
+    service,
+    (state) => state.context.main.planeUIGroup
+  )
 
   useEffect(() => {
     state.context.main.collapseUIButton = collapseUIButton.current
@@ -16,7 +36,16 @@ function CollapseUIButton(props) {
 
   const handleToggle = () => {
     send('TOGGLE_UI_COLLAPSED')
-    toggleUICollapsed(state.context)
+    toggleUICollapsed(
+      uiContainer,
+      uiCollapsed,
+      selectedName,
+      service,
+      use2D,
+      planeUIGroup,
+      viewMode,
+      mainPlaneUIGroup
+    )
   }
 
   return (

--- a/src/Main/AnnotationsButton.jsx
+++ b/src/Main/AnnotationsButton.jsx
@@ -7,7 +7,7 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
-const AnnotationsButton = React.memo(function AnnotationsButton(props) {
+function AnnotationsButton(props) {
   const { service } = props
   const stateAnnotationsEnabled = useSelector(
     service,
@@ -31,6 +31,6 @@ const AnnotationsButton = React.memo(function AnnotationsButton(props) {
       </Button>
     </OverlayTrigger>
   )
-})
+}
 
 export default AnnotationsButton

--- a/src/Main/AxesButton.jsx
+++ b/src/Main/AxesButton.jsx
@@ -7,7 +7,7 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
-const AxesButton = React.memo(function AxesButton(props) {
+function AxesButton(props) {
   const { service } = props
   const stateAxesEnabled = useSelector(
     service,
@@ -28,6 +28,6 @@ const AxesButton = React.memo(function AxesButton(props) {
       </Button>
     </OverlayTrigger>
   )
-})
+}
 
 export default AxesButton

--- a/src/Main/BackgroundColorButton.jsx
+++ b/src/Main/BackgroundColorButton.jsx
@@ -7,7 +7,7 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
-const BackgroundColorButton = React.memo(function BackgroundColorButton(props) {
+function BackgroundColorButton(props) {
   const { service } = props
   const stateBackgroundColorEnabled = useSelector(
     service,
@@ -33,6 +33,6 @@ const BackgroundColorButton = React.memo(function BackgroundColorButton(props) {
       </Button>
     </OverlayTrigger>
   )
-})
+}
 
 export default BackgroundColorButton

--- a/src/Main/FullscreenButton.jsx
+++ b/src/Main/FullscreenButton.jsx
@@ -7,7 +7,7 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
-const FullscreenButton = React.memo(function FullscreenButton(props) {
+function FullscreenButton(props) {
   const { service } = props
   const stateFullscreenEnabled = useSelector(
     service,
@@ -31,6 +31,6 @@ const FullscreenButton = React.memo(function FullscreenButton(props) {
       </Button>
     </OverlayTrigger>
   )
-})
+}
 
 export default FullscreenButton

--- a/src/Main/MainInterface.jsx
+++ b/src/Main/MainInterface.jsx
@@ -1,4 +1,4 @@
-import { useActor } from '@xstate/react'
+import { useSelector } from '@xstate/react'
 import React, { useEffect, useRef } from 'react'
 import AnnotationsButton from './AnnotationsButton'
 import AxesButton from './AxesButton'
@@ -16,11 +16,13 @@ const STYLE = { width: '20%' }
 
 function MainInterface(props) {
   const { service } = props
-  const [state] = useActor(service)
   const mainUIGroup = useRef(null)
 
+  let use2D = useSelector(service, (state) => state.context.use2D)
+  let uiGroups = useSelector(service, (state) => state.context.uiGroups)
+
   useEffect(() => {
-    state.context.uiGroups.set('main', mainUIGroup.current)
+    uiGroups.set('main', mainUIGroup.current)
   }, [])
 
   return (
@@ -29,14 +31,14 @@ function MainInterface(props) {
         <div className="mainUIRow">
           <ScreenshotButton {...props} />
           <FullscreenButton {...props} />
-          {!state.context.use2D && <RotateButton {...props} />}
+          {!use2D && <RotateButton {...props} />}
           <AnnotationsButton {...props} />
           <AxesButton {...props} />
-          {!state.context.use2D && <ViewPlanesToggle {...props} />}
+          {!use2D && <ViewPlanesToggle {...props} />}
           <BackgroundColorButton {...props} />
-          {state.context.use2D && <ResetCameraButton {...props} />}
+          {use2D && <ResetCameraButton {...props} />}
         </div>
-        {!state.context.use2D && (
+        {!use2D && (
           <div className="mainUIRow">
             <ViewModeButtons {...props} />
             <ResetCameraButton style={STYLE} {...props} />

--- a/src/Main/PlaneSliders.jsx
+++ b/src/Main/PlaneSliders.jsx
@@ -18,6 +18,19 @@ import '../style.css'
 function PlaneSliders(props) {
   const { service } = props
   const stateContextMain = useSelector(service, (state) => state.context.main)
+  const stateContextMainXSlice = useSelector(
+    service,
+    (state) => state.context.main[`xSlice`]
+  )
+  const stateContextMainYSlice = useSelector(
+    service,
+    (state) => state.context.main[`ySlice`]
+  )
+  const stateContextMainZSlice = useSelector(
+    service,
+    (state) => state.context.main[`zSlice`]
+  )
+
   const stateContextUiDrawer = useSelector(
     service,
     (state) => state.context.uiDrawer

--- a/src/Main/ResetCameraButton.jsx
+++ b/src/Main/ResetCameraButton.jsx
@@ -5,7 +5,7 @@ import Image from 'react-bootstrap/Image'
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 
-const ResetCamerButton = React.memo(function ResetCamerButton({ service }) {
+function ResetCamerButton({ service }) {
   const { send } = service
 
   return (
@@ -22,6 +22,6 @@ const ResetCamerButton = React.memo(function ResetCamerButton({ service }) {
       </Button>
     </OverlayTrigger>
   )
-})
+}
 
 export default ResetCamerButton

--- a/src/Main/RotateButton.jsx
+++ b/src/Main/RotateButton.jsx
@@ -7,7 +7,7 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 import cn from 'classnames'
 
-const RotateButton = React.memo(function RotateButton(props) {
+function RotateButton(props) {
   const { service } = props
   const stateRotateEnabled = useSelector(
     service,
@@ -31,6 +31,6 @@ const RotateButton = React.memo(function RotateButton(props) {
       </Button>
     </OverlayTrigger>
   )
-})
+}
 
 export default RotateButton

--- a/src/Main/ScreenshotButton.jsx
+++ b/src/Main/ScreenshotButton.jsx
@@ -5,7 +5,7 @@ import Image from 'react-bootstrap/Image'
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 
-const ScreenshotButton = React.memo(function ScreenshotButton(props) {
+function ScreenshotButton(props) {
   const { service } = props
   const send = service.send
 
@@ -22,6 +22,6 @@ const ScreenshotButton = React.memo(function ScreenshotButton(props) {
       </Button>
     </OverlayTrigger>
   )
-})
+}
 
 export default ScreenshotButton

--- a/src/Main/ViewModeButtons.jsx
+++ b/src/Main/ViewModeButtons.jsx
@@ -39,7 +39,7 @@ function ViewButton(props) {
   )
 }
 
-const ViewModeButtons = React.memo(function ViewModeButtons(props) {
+function ViewModeButtons(props) {
   const { service } = props
 
   return [
@@ -72,6 +72,6 @@ const ViewModeButtons = React.memo(function ViewModeButtons(props) {
       service={service}
     ></ViewButton>
   ))
-})
+}
 
 export default ViewModeButtons

--- a/src/Main/ViewPlanesToggle.jsx
+++ b/src/Main/ViewPlanesToggle.jsx
@@ -6,7 +6,7 @@ import Image from 'react-bootstrap/Image'
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 
-const ViewPlanesToggle = React.memo(function ViewPlanesToggle(props) {
+function ViewPlanesToggle(props) {
   const { service } = props
   const stateSlicingPlanes = useSelector(service, (state) => state.context.main)
   const send = service.send
@@ -56,6 +56,6 @@ const ViewPlanesToggle = React.memo(function ViewPlanesToggle(props) {
       </Button>
     </OverlayTrigger>
   )
-})
+}
 
 export default ViewPlanesToggle

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react'
-import { useActor } from '@xstate/react'
+import { useSelector } from '@xstate/react'
 import { Drawer } from '@mui/material'
 import './Panel.css'
 
@@ -7,11 +7,19 @@ function Panel(props) {
   const { children, service } = props
   const uiPanel = useRef(null)
   const uiDrawer = useRef(null)
-  const [state] = useActor(service)
+  let stateContextUIDrawer = useSelector(
+    service,
+    (state) => state.context.uiDrawer
+  )
+  let stateContextUIPanel = useSelector(
+    service,
+    (state) => state.context.uiPanel
+  )
+  const uiCollapsed = useSelector(service, (state) => state.context.uiCollapsed)
 
   useEffect(() => {
-    state.context.uiPanel = uiPanel.current
-    state.context.uiDrawer = uiDrawer.current
+    stateContextUIPanel = uiPanel.current
+    stateContextUIDrawer = uiDrawer.current
   }, [])
 
   return (
@@ -20,7 +28,7 @@ function Panel(props) {
         className="drawer"
         variant="persistent"
         anchor="left"
-        open={!state.context.uiCollapsed}
+        open={!uiCollapsed}
       >
         <div ref={uiDrawer}>
           {React.Children.map(children, (child) => {

--- a/src/toggleUICollapsed.jsx
+++ b/src/toggleUICollapsed.jsx
@@ -1,24 +1,34 @@
-function toggleUICollapsed(context, _event, actionMeta) {
-  if (!context.uiContainer) {
+function toggleUICollapsed(
+  uiContainer,
+  uiCollapsed,
+  selectedName,
+  service,
+  use2D,
+  planeUIGroup,
+  viewMode,
+  mainPlaneUIGroup,
+  _event,
+  actionMeta
+) {
+  if (!uiContainer) {
     return
   }
   if (actionMeta) {
-    context.uiCollapsed =
-      actionMeta.state.value.active.uiCollapsed === 'enabled'
+    uiCollapsed = actionMeta.state.value.active.uiCollapsed === 'enabled'
   }
 
-  if (!context.uiCollapsed && context.images.selectedName) {
-    context.service.send({
+  if (!uiCollapsed && selectedName) {
+    service.send({
       type: 'SELECT_LAYER',
-      data: context.images.selectedName
+      data: selectedName
     })
   }
 
-  if (!context.use2D && !!context.main.planeUIGroup) {
-    if (context.uiCollapsed && context.main.viewMode === 'Volume') {
-      context.main.planeUIGroup.style.display = 'none'
+  if (!use2D && !!planeUIGroup) {
+    if (uiCollapsed && viewMode === 'Volume') {
+      mainPlaneUIGroup.style.display = 'none'
     } else {
-      context.main.planeUIGroup.style.display = 'block'
+      mainPlaneUIGroup.style.display = 'block'
     }
   }
 }


### PR DESCRIPTION
This avoids unnecessary re-renderings at the parent/top level 

**Phase 1: Panel**
- Panel.jsx: Select only necessary state components

 
 **Phase 2: AppToolBar**
 - ToggleUICollapsed.jsx: changed the arguments and made according adjustments throughout the code;
-  AppToolBar.jsx:  changed toggleUICollapsed according to the previous item. Selected the necessary state components for that to work. Notice that here we must use declar contextCollapseUIButton using `let` opposed to `const` since we assign a value to it down the line;
- CollapseUIButton.jsx:  changed toggleUICollapsed according to the previous item. Selected the necessary state components for that to work.


 **Phase 3: MainInterface**
 - MainInterface.jsx: we use `useSelector` to call for only the necessary state components. This makes the plane sliders disappear. That is due to the fact that the values for `state.context.main[plane]` do not get updated to their initial position, returning a null value;
 - PlaneSliders.jsx: The fix for the above issue is explicitly call for such variables in PlaneSliders so the component gets re-rendered when such values change (right after initialization of plane positions and along the rest of the lifecycle).
 

 **Phase 4: Adjustments at low-level**
 - src/Main/*: Delete React.memo. Once the parent level gets optimized, the use of React.memo is not necessary.