### PR TITLE
feat(PlaneSliders/Style): Change icon image color if background is black

### DIFF
--- a/src/Main/PlaneSliders.jsx
+++ b/src/Main/PlaneSliders.jsx
@@ -31,6 +31,10 @@ function PlaneSliders(props) {
     service,
     (state) => state.context.container.clientHeight
   )
+  const stateBackgroundColorEnabled = useSelector(
+    service,
+    (state) => state.context.main.selectedBackgroundColor
+  )
   const send = service.send
   const xVisibility = useRef(null)
   const yVisibility = useRef(null)
@@ -118,7 +122,8 @@ function PlaneSliders(props) {
                       viewMode !== 'Volume' ? 'hiddenSlider' : ''
                     }`,
                     {
-                      checked: slicingPlanes[plane].visible
+                      checked: slicingPlanes[plane].visible,
+                      inverted_filter: stateBackgroundColorEnabled === 1
                     }
                   )}
                   onClick={(_e) => {
@@ -149,7 +154,8 @@ function PlaneSliders(props) {
                         : ''
                     }`,
                     {
-                      checked: slicingPlanes[plane].scroll
+                      checked: slicingPlanes[plane].scroll,
+                      inverted_filter: stateBackgroundColorEnabled === 1
                     }
                   )}
                   onClick={(_e) => {

--- a/src/style.css
+++ b/src/style.css
@@ -30,6 +30,10 @@
   margin-right: 10px;
 }
 
+.inverted_filter {
+  filter: invert(100%);
+}
+
 .categoricalMenu {
   margin: 0 5px !important;
 }


### PR DESCRIPTION
Since we have deleted the grayish background color for the PlaneSliders menu (commit ba5b77f), when we changed the background color it was not possible to see the Plane Visibility and the Toggle Scroll buttons.
Here we cahnge the color of such buttons to white when the background is dark.