### PR TITLE
feat(labelImageMenu): Set up to change from MUI to bootstrap

### DIFF
--- a/src/Images/CategoricalIconSelector.jsx
+++ b/src/Images/CategoricalIconSelector.jsx
@@ -8,6 +8,8 @@ import NavDropdown from 'react-bootstrap/NavDropdown'
 import Image from 'react-bootstrap/Image'
 import Row from 'react-bootstrap/Row'
 import Col from 'react-bootstrap/Col'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
 
 function CategoricalIconSelector(props) {
   const { service } = props
@@ -46,9 +48,11 @@ function CategoricalIconSelector(props) {
   }
 
   const [icon, setIcon] = useState(categoricalPresetIcons[0].icon)
+  const [nameColor, setNameColor] = useState(categoricalPresetIcons[0].name)
 
   const handleChange = (lut) => {
     setIcon(lut.icon)
+    setNameColor(lut.name)
     send({
       type: 'LABEL_IMAGE_LOOKUP_TABLE_CHANGED',
       data: { name, lookupTable: lut.name }
@@ -56,39 +60,41 @@ function CategoricalIconSelector(props) {
   }
 
   return (
-    <Navbar
-      bg="light"
-      variant="light"
-      ref={iconSelector}
-      className="categoricalMenuForm"
-      style={{ width: '154px', margin: '0 5px' }}
-    >
-      <NavDropdown
-        title=""
-        id="basic-nav-dropdown"
-        className="form-control categoricalDropDown"
-        value={currentCategoricalPreset()}
+    <OverlayTrigger transition={false} overlay={<Tooltip>{nameColor}</Tooltip>}>
+      <Navbar
+        bg="light"
+        variant="light"
+        ref={iconSelector}
+        className="categoricalMenuForm"
+        style={{ width: '154px', margin: '0 5px' }}
       >
-        <Container>
-          <Row xs={4} md={2}>
-            {categoricalPresetIcons.map((preset, idx) => (
-              <Container key={idx} className="categoricalColContainer">
-                <Col className="categoricalCol">
-                  <NavDropdown.Item
-                    key={idx}
-                    style={{ minWidth: '100%' }}
-                    onClick={() => handleChange(preset)}
-                  >
-                    <Image src={preset.icon} className="colorMapIcon" />
-                  </NavDropdown.Item>
-                </Col>
-              </Container>
-            ))}
-          </Row>
-        </Container>
-      </NavDropdown>
-      <Image src={icon} className="overlayImage"></Image>
-    </Navbar>
+        <NavDropdown
+          title=""
+          id="basic-nav-dropdown"
+          className="form-control categoricalDropDown"
+          value={currentCategoricalPreset()}
+        >
+          <Container>
+            <Row xs={4} md={2}>
+              {categoricalPresetIcons.map((preset, idx) => (
+                <Container key={idx} className="categoricalColContainer">
+                  <Col className="categoricalCol">
+                    <NavDropdown.Item
+                      key={idx}
+                      style={{ minWidth: '100%' }}
+                      onClick={() => handleChange(preset)}
+                    >
+                      <Image src={preset.icon} className="colorMapIcon" />
+                    </NavDropdown.Item>
+                  </Col>
+                </Container>
+              ))}
+            </Row>
+          </Container>
+        </NavDropdown>
+        <Image src={icon} className="overlayImage"></Image>
+      </Navbar>
+    </OverlayTrigger>
   )
 }
 

--- a/src/Images/CategoricalIconSelector.jsx
+++ b/src/Images/CategoricalIconSelector.jsx
@@ -1,17 +1,23 @@
 import React, { useEffect, useRef } from 'react'
 import { useActor } from '@xstate/react'
-import { FormControl, Icon, MenuItem, Select } from '@mui/material'
 import CategoricalPresetIcons from '../CategoricalPresetIcons'
 import '../style.css'
+import Navbar from 'react-bootstrap/Navbar'
+import Container from 'react-bootstrap/Container'
+import NavDropdown from 'react-bootstrap/NavDropdown'
+import Image from 'react-bootstrap/Image'
+import Form from 'react-bootstrap/Form'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
 
 function CategoricalIconSelector(props) {
   const { service } = props
   const iconSelector = useRef(null)
   const [state, send] = useActor(service)
 
-  let catergoricalPresetIcons = []
+  let categoricalPresetIcons = []
   CategoricalPresetIcons.forEach((value, key) => {
-    catergoricalPresetIcons.push({
+    categoricalPresetIcons.push({
       name: key,
       icon: value
     })
@@ -21,7 +27,7 @@ function CategoricalIconSelector(props) {
     state.context.images.labelImageIconSelector = iconSelector
   }, [])
 
-  const currentCatergoricalPreset = () => {
+  const currentCategoricalPreset = () => {
     const name = state.context.images.selectedName
     if (state.context.images.actorContext) {
       const actorContext = state.context.images.actorContext.get(name)
@@ -38,35 +44,54 @@ function CategoricalIconSelector(props) {
     })
   }
 
+  // return (
+  //   <Navbar
+  //     bg="light"
+  //     variant="light"
+  //     ref={iconSelector}
+  //     className="categoricalMenu"
+  //     style={{ width: '154px', margin: '0 5px' }}
+  //   >
+  //     <NavDropdown
+  //       title="Dropdown"
+  //       id="basic-nav-dropdown"
+  //       className="form-control"
+  //       value={currentCategoricalPreset()}
+  //       onChange={(e) => {
+  //         handleChange(e.target.value)
+  //       }}
+  //     >
+  //       {categoricalPresetIcons.map((preset, idx) => (
+  //         <NavDropdown.Item key={idx} style={{ minWidth: '100%' }}>
+  //           <Container>
+  //             <Navbar.Brand>
+  //               <Image alt="" src={preset.icon} className="colorMapIcon" />
+  //             </Navbar.Brand>
+  //           </Container>
+  //         </NavDropdown.Item>
+  //       ))}
+  //     </NavDropdown>
+  //   </Navbar>
+  // )
+
   return (
-    <FormControl
-      variant="outlined"
-      size="small"
+    <Form.Control
+      as="select"
       ref={iconSelector}
-      style={{ width: '154px', margin: '0 5px' }}
+      className="categoricalMenuForm"
+      // style={{ width: '20px !important' }}
+      onChange={(e) => {
+        handleChange(e.target.value)
+      }}
+      value={currentCategoricalPreset()}
     >
-      <Select
-        value={currentCatergoricalPreset()}
-        style={{ height: '40px' }}
-        onChange={(e) => {
-          handleChange(e.target.value)
-        }}
-        MenuProps={{
-          anchorEl: iconSelector.current,
-          disablePortal: true,
-          keepMounted: true,
-          classes: { list: 'categoricalMenu' }
-        }}
-      >
-        {catergoricalPresetIcons.map((preset, idx) => (
-          <MenuItem key={idx} value={preset.name} style={{ minWidth: '100%' }}>
-            <Icon style={{ width: '100%' }}>
-              <img className="colorMapIcon" src={preset.icon} />
-            </Icon>
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+      {categoricalPresetIcons.map((preset, idx) => (
+        <option key={idx} style={{ minWidth: '100%' }} value={preset.value}>
+          {preset.name}
+          {/* <Image className="colorMapIcon" src={preset.icon} /> */}
+        </option>
+      ))}
+    </Form.Control>
   )
 }
 

--- a/src/Images/LabelImageColorWidget.jsx
+++ b/src/Images/LabelImageColorWidget.jsx
@@ -1,8 +1,11 @@
 import React, { useEffect, useRef } from 'react'
-import { useActor } from '@xstate/react'
-import { Icon, Slider, Tooltip } from '@mui/material'
+import { useSelector } from '@xstate/react'
 import CategoricalIconSelector from './CategoricalIconSelector'
 import { opacityIconDataUri } from 'itk-viewer-icons'
+import Form from 'react-bootstrap/Form'
+import Image from 'react-bootstrap/Image'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
 import '../style.css'
 
 function LabelImageColorWidget(props) {
@@ -10,13 +13,19 @@ function LabelImageColorWidget(props) {
   const labelImageColorUIGroup = useRef(null)
   const opacityDiv = useRef(null)
   const blendElement = useRef(null)
-  const [state, send] = useActor(service)
+  const send = service.send
 
-  const name = state.context.images.selectedName
-  const actorContext = state.context.images.actorContext.get(name)
+  const name = useSelector(
+    service,
+    (state) => state.context.images.selectedName
+  )
+  const actorContext = useSelector(service, (state) =>
+    state.context.images.actorContext.get(name)
+  )
 
   useEffect(() => {
-    state.context.images.labelImageColorUIGroup = labelImageColorUIGroup.current
+    service.machine.context.images.labelImageColorUIGroup =
+      labelImageColorUIGroup.current
   }, [])
 
   const blendChanged = (val) => {
@@ -30,29 +39,25 @@ function LabelImageColorWidget(props) {
     <div ref={labelImageColorUIGroup} className="uiGroup">
       <div className="uiRow">
         <CategoricalIconSelector {...props} />
-        <Tooltip
-          ref={opacityDiv}
-          title="Label image blend"
-          PopperProps={{
-            anchorEl: opacityDiv.current,
-            disablePortal: true,
-            keepMounted: true
-          }}
-          style={{ marginRight: '5px' }}
+        <OverlayTrigger
+          transition={false}
+          overlay={<Tooltip>Label image blend</Tooltip>}
         >
-          <Icon>
-            <img src={opacityIconDataUri} />
-          </Icon>
-        </Tooltip>
-        <Slider
+          <div className="icon-image" ref={opacityDiv}>
+            <Image src={opacityIconDataUri}></Image>
+          </div>
+        </OverlayTrigger>
+        <Form.Control
+          type="range"
+          custom
           ref={blendElement}
           className="slider"
           min={0}
           max={1}
           value={actorContext.labelImageBlend}
           step={0.01}
-          onChange={(_e, val) => {
-            blendChanged(val)
+          onChange={(_e) => {
+            blendChanged(_e.target.value)
           }}
         />
       </div>

--- a/src/Images/LabelMapWeightWidget.jsx
+++ b/src/Images/LabelMapWeightWidget.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
-import { useActor } from '@xstate/react'
-import { Slider } from '@mui/material'
+import { useSelector } from '@xstate/react'
+import Form from 'react-bootstrap/Form'
 import MapWeightSelector from './MapWeightSelector'
 import '../style.css'
 
@@ -8,15 +8,32 @@ function LabelMapWeightWidget(props) {
   const { service } = props
   const labelImageWeightUIGroup = useRef(null)
   const weightSlider = useRef(null)
-  const [state, send] = useActor(service)
+  const send = service.send
 
-  const name = state.context.images.selectedName
-  const actorContext = state.context.images.actorContext.get(name)
+  const name = useSelector(
+    service,
+    (state) => state.context.images.selectedName
+  )
+  const actorContext = useSelector(service, (state) =>
+    state.context.images.actorContext.get(state.context.images.selectedName)
+  )
+  const actorContextlabelImageWeights = useSelector(
+    service,
+    (state) =>
+      state.context.images.actorContext.get(state.context.images.selectedName)
+        .labelImageWeights
+  )
+  const actorContextSelectedLabel = useSelector(
+    service,
+    (state) =>
+      state.context.images.actorContext.get(state.context.images.selectedName)
+        .selectedLabel
+  )
 
   useEffect(() => {
-    state.context.images.labelImageWeightUIGroup =
+    service.machine.context.images.labelImageWeightUIGroup =
       labelImageWeightUIGroup.current
-    state.context.images.labelImageWeightSlider = weightSlider.current
+    service.machine.context.images.labelImageWeightSlider = weightSlider.current
     actorContext.labelImageToggleWeight = 1.0
   }, [])
 
@@ -25,7 +42,7 @@ function LabelMapWeightWidget(props) {
   }, [actorContext.selectedLabel])
 
   const weightChanged = (val) => {
-    const labelImageWeights = actorContext.labelImageWeights
+    const labelImageWeights = actorContextlabelImageWeights
     if (actorContext.selectedLabel === 'all') {
       for (const label of labelImageWeights.keys()) {
         labelImageWeights.set(label, val)
@@ -41,11 +58,11 @@ function LabelMapWeightWidget(props) {
   }
 
   const sliderValue = () => {
-    const labelImageWeights = actorContext.labelImageWeights
+    const labelImageWeights = actorContextlabelImageWeights
     if (actorContext.selectedLabel === 'all') {
       return actorContext.labelImageToggleWeight
     } else {
-      return labelImageWeights.get(actorContext.selectedLabel)
+      return labelImageWeights.get(actorContextSelectedLabel)
     }
   }
 
@@ -53,17 +70,19 @@ function LabelMapWeightWidget(props) {
     <div ref={labelImageWeightUIGroup} className="uiGroup">
       <div className="uiRow">
         <MapWeightSelector {...props} />
-        <Slider
+        <Form.Control
+          type="range"
+          custom
           ref={weightSlider}
           className="slider"
           min={0}
           max={1}
           value={sliderValue()}
           step={0.05}
-          onChange={(_e, val) => {
-            weightChanged(val)
+          onChange={(_e) => {
+            weightChanged(_e.target.value)
           }}
-          style={{ marginLeft: '5px' }}
+          style={{ marginLeft: '5px', marginBottom: '5px' }}
         />
       </div>
     </div>

--- a/src/Images/MapWeightSelector.jsx
+++ b/src/Images/MapWeightSelector.jsx
@@ -1,25 +1,15 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useState } from 'react'
 import { useSelector } from '@xstate/react'
 import Form from 'react-bootstrap/Form'
 import '../style.css'
 
 function MapWeightSelector(props) {
   const { service } = props
-  const labelImageWeightUIGroup = useRef(null)
-  const labelSelector = useRef(null)
   const send = service.send
-
   let labelMapWeights = [{ name: 'All', value: 'all' }]
   const name = useSelector(
     service,
     (state) => state.context.images.selectedName
-  )
-  const actorContext = useSelector(
-    service,
-    (state) => state.context.images.actorContext
-  )
-  const actorContextName = useSelector(service, (state) =>
-    state.context.images.actorContext.get(state.context.images.selectedName)
   )
   const labelNames = useSelector(
     service,
@@ -27,6 +17,7 @@ function MapWeightSelector(props) {
       state.context.images.actorContext.get(state.context.images.selectedName)
         .labelNames
   )
+
   labelNames.forEach((value, key) => {
     labelMapWeights.push({
       name: value,
@@ -34,40 +25,28 @@ function MapWeightSelector(props) {
     })
   })
 
-  useEffect(() => {
-    service.machine.context.images.labelImageWeightUIGroup =
-      labelImageWeightUIGroup.current
-    service.machine.context.images.labelSelector = labelSelector.current
-  }, [])
+  const [weightValue, setWeightValue] = useState(labelMapWeights[0].name)
 
-  const currentMapWeight = () => {
-    if (actorContext) {
-      const actorContext = actorContextName
-      return actorContext.selectedLabel
-    }
-    return ''
-  }
-
-  const handleChange = (label) => {
-    console.log(label)
+  const handleChange = (event) => {
+    setWeightValue(event.target.value)
     send({
       type: 'LABEL_IMAGE_SELECTED_LABEL_CHANGED',
-      data: { name, selectedLabel: label }
+      data: { name, selectedLabel: weightValue }
     })
   }
 
   return (
-    <div ref={labelImageWeightUIGroup} className="uiGroup">
+    <div className="uiGroup">
       <div className="uiRow">
         <Form.Control
           as="select"
-          ref={labelSelector}
+          value={weightValue}
           onChange={(e) => {
-            handleChange(e.target.value)
+            handleChange(e)
           }}
         >
           {labelMapWeights.map((weight, idx) => (
-            <option key={idx} value={currentMapWeight()}>
+            <option key={idx} value={weight.value}>
               {weight.name}
             </option>
           ))}

--- a/src/style.css
+++ b/src/style.css
@@ -8,14 +8,29 @@
   margin-left: 10px;
 }
 
+.categoricalCol {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  padding-top:3px !important;
+}
+
+.categoricalColContainer {
+  padding-left: 0px !important;
+  padding-right: 0px !important;
+}
+
+.categoricalDropDown {
+ padding: 0 0 !important;
+}
 .categoricalMenu {
   margin: 0 5px !important;
 }
 
 .categoricalMenuForm{
   width: 150px !important;
-  margin-right: 3px !important;
+  margin-right: 10px !important;
   margin-left: 3px !important;
+  position: relative !important;
 }
 
 .categoricalRoot {
@@ -30,13 +45,15 @@
 }
 
 code.uiContainer {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Mo naco, Consolas, 'Courier New',
     monospace;
 }
 
 .colorMapIcon {
   height: inherit;
-  width: 100%;
+  width: 100% !important;
+  height: 100%;
+  min-height: 30px;
   margin: 0 3px;
 }
 
@@ -66,6 +83,14 @@ code.uiContainer {
   color: white;
   font-size: 1.0em;
   width: 80px;
+}
+
+.dropdown-menu {
+  min-width: 300px !important;
+
+}
+.dropdown-toggle:empty::after {
+  margin-left: 100% !important;
 }
 
 .gradientOpacityScale {
@@ -261,6 +286,14 @@ code.uiContainer {
 
 .numberInput {
   min-width: 98px;
+}
+
+.overlayImage{
+  position: absolute;
+  width: 85%;
+  height: 100%;
+  vertical-align: auto;
+  pointer-events: none;
 }
 
 .piecewiseWidget {

--- a/src/style.css
+++ b/src/style.css
@@ -12,6 +12,12 @@
   margin: 0 5px !important;
 }
 
+.categoricalMenuForm{
+  width: 150px !important;
+  margin-right: 3px !important;
+  margin-left: 3px !important;
+}
+
 .categoricalRoot {
   height: 250px;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -290,8 +290,9 @@ code.uiContainer {
 
 .overlayImage{
   position: absolute;
+  padding: 5px 5px;
   width: 85%;
-  height: 100%;
+  height: 100%; */
   vertical-align: auto;
   pointer-events: none;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -292,7 +292,7 @@ code.uiContainer {
   position: absolute;
   padding: 5px 5px;
   width: 85%;
-  height: 100%; */
+  height: 100%; 
   vertical-align: auto;
   pointer-events: none;
 }


### PR DESCRIPTION
- style.css: include a selector `.categoricalMenuForm` to limit the space the dropdown takes;
 - LabelMapWeitght: translate and optimize rendering using `useSelector`;
 - MapWeightSelector: translate and optimize rendering using `useSelector`;
 - LabelImageColorWidget: translate and optimize rendering using `useSelector`;
 - CategoricalIconSelector: 
      1.  -Use of `NavDropdown.Item`, which supports icons/images in contrast with Form.Control `option`;
      2.  Introduction of Row, Col, and Container to show the colorIcons in two columns;
      3.  NavBar main does not support icons (as far as we know). The fix to show the current selected item in the main window was using an overlay image with `pointer events: none` so the click pass through it;
      4.  Other adjustments to padding and styling to make the icons big enough;

Co-authored-by: Paul Elliott <paul.elliott@kitware.com>