### PR TITLE
fix(otp-error): Attempt to fix OTP error by setting npm 2fa to auth-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "keywords": [
     "react",
-    "material-ui",
+    "boostrap-ui",
     "ui",
     "itk-viewer"
   ],


### PR DESCRIPTION
This attempts to fix the problem when publishing last version (commit edc929a09c8c49ebd774c0599feef7f46323bf7c).

Steps:
 - set 2fa to auth only again,
 - regenerate a new token

This also includes a small fix in the UI keyword so we can have a new commit.