### PR TITLE
feat(documentation): Update itkwidgets python wheel for jupyter lite

### DIFF
--- a/docs/jupyterlite/jupyterlite_config.json
+++ b/docs/jupyterlite/jupyterlite_config.json
@@ -8,7 +8,7 @@
             "https://files.pythonhosted.org/packages/14/f7/ea85b5e4f59db353340543d450cd3d1c5befcde8bee0cc41a9de78fed82f/itkwasm-1.0b1-py3-none-any.whl",
             "https://files.pythonhosted.org/packages/e5/e7/3df714a23e165e1097825a6f53c18c3d1c7850de58b5c4ffe6c5a15518bf/imjoy_rpc-0.5.13-py3-none-any.whl",
             "https://files.pythonhosted.org/packages/69/d9/5a6c8af2f4b4f49a809ae316ae4c12937d7dfda4e5b2f9e4167df5f15c0e/imjoy_utils-0.1.2-py3-none-any.whl",
-            "https://files.pythonhosted.org/packages/d1/2c/b2ac53f14e28a2c84446f84b6463561b0b66c839f2f7f2b723264a6a03ec/itkwidgets-1.0a5-py3-none-any.whl"
+            "https://files.pythonhosted.org/packages/84/d0/6aec1789299280454f67b21a7557eff62c311c32083c0f0403dd565b1b5f/itkwidgets-1.0a6-py3-none-any.whl"
         ]
     }
 }


### PR DESCRIPTION
For future reference, here is what I did to update the piplite_urls in jupyterlite_config.json.

 - Go to [Pypi website](https://pypi.org/);
 - Type the name of the package;
 - Go to the exact version of the package you want to be available offline;
 - Click on download files tab;
 - Go to the hash files and check the BLAKE2-256 hash, e.g., for itkwidgets v 1.0a5:
`d12cb2ac53f14e28a2c84446f84b6463561b0b66c839f2f7f2b723264a6a03ec`
 - Include the link in the `piplite_urls` list in `jupyterlite_config`:
`https://files.pythonhosted.org/packages/d1/2c/b2ac53f14e28a2c84446f84b6463561b0b66c839f2f7f2b723264a6a03ec/itkwidgets-1.0a5-py3-none-any.whl`
In which the last chunk is just the name of the built distribution.