### PR TITLE
fix(LabelMapWeightWidget, LabelImageColorWidget): sliders ticks move now

### DIFF
--- a/src/Images/LabelImageColorWidget.jsx
+++ b/src/Images/LabelImageColorWidget.jsx
@@ -7,6 +7,10 @@ import Image from 'react-bootstrap/Image'
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 import '../style.css'
+import getSelectedImageContext from './getSelectedImageContext'
+
+const selectLabelImageBlend = (state) =>
+  getSelectedImageContext(state).labelImageBlend
 
 function LabelImageColorWidget(props) {
   const { service } = props
@@ -19,9 +23,7 @@ function LabelImageColorWidget(props) {
     service,
     (state) => state.context.images.selectedName
   )
-  const actorContext = useSelector(service, (state) =>
-    state.context.images.actorContext.get(name)
-  )
+  const labelImageBlend = useSelector(service, selectLabelImageBlend)
 
   useEffect(() => {
     service.machine.context.images.labelImageColorUIGroup =
@@ -54,7 +56,7 @@ function LabelImageColorWidget(props) {
           className="slider"
           min={0}
           max={1}
-          value={actorContext.labelImageBlend}
+          value={labelImageBlend}
           step={0.01}
           onChange={(_e) => {
             blendChanged(_e.target.value)

--- a/src/Images/LabelMapWeightWidget.jsx
+++ b/src/Images/LabelMapWeightWidget.jsx
@@ -5,6 +5,15 @@ import MapWeightSelector from './MapWeightSelector'
 import '../style.css'
 import getSelectedImageContext from './getSelectedImageContext'
 
+const selectSelectedLabelImageWeight = (state) => {
+  const actorContext = getSelectedImageContext(state)
+  const { labelImageToggleWeight, labelImageWeights, selectedLabel } =
+    actorContext
+  return actorContext.selectedLabel === 'all'
+    ? labelImageToggleWeight
+    : labelImageWeights.get(selectedLabel) ?? 1
+}
+
 function LabelMapWeightWidget({ service }) {
   const labelImageWeightUIGroup = useRef(null)
   const weightSlider = useRef(null)
@@ -32,6 +41,11 @@ function LabelMapWeightWidget({ service }) {
         .selectedLabel
   )
 
+  const selectedLabelImageWeight = useSelector(
+    service,
+    selectSelectedLabelImageWeight
+  )
+
   useEffect(() => {
     service.machine.context.images.labelImageWeightUIGroup =
       labelImageWeightUIGroup.current
@@ -53,11 +67,6 @@ function LabelMapWeightWidget({ service }) {
       data: { name, labelImageWeights }
     })
   }
-
-  const selectedLabelImageWeight =
-    actorContext.selectedLabel === 'all'
-      ? actorContext.labelImageToggleWeight
-      : labelImageWeights.get(selectedLabel) ?? 1
 
   return (
     <div ref={labelImageWeightUIGroup} className="uiGroup">


### PR DESCRIPTION
Label map slider ticks influencing rendering did not move, now they do.