### PR TITLE
fix(ScaleSelector): use inherent height of element, not fixed

### DIFF
--- a/src/Images/ScaleSelector.jsx
+++ b/src/Images/ScaleSelector.jsx
@@ -61,7 +61,6 @@ function ScaleSelector({ service }) {
         style={{
           display: 'flex',
           alignSelf: 'center',
-          height: '25px',
           marginRight: '5px'
         }}
       >


### PR DESCRIPTION
When there is only 1 component, scale selector row height was too small.